### PR TITLE
Feat: copy filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ When you call the `setup()` function, the following commands are defined.
   - Copy full path of current file
 - `CopyRelativePath`
   - Copy relative path of current file
+- `CopyFileName`
+  - Copy name of current file without extension
 
 ## License
 

--- a/lua/socks-copypath/api.lua
+++ b/lua/socks-copypath/api.lua
@@ -16,4 +16,10 @@ function Api.copy_absolute_path(cfg)
 	return path
 end
 
+function Api.copy_file_name(cfg)
+	local path = vim.fn["expand"]("%:t")
+	set_register(cfg.register, path)
+	return path
+end
+
 return Api

--- a/lua/socks-copypath/api.lua
+++ b/lua/socks-copypath/api.lua
@@ -17,7 +17,7 @@ function Api.copy_absolute_path(cfg)
 end
 
 function Api.copy_file_name(cfg)
-	local path = vim.fn["expand"]("%:t")
+	local path = vim.fn["expand"]("%:t:r")
 	set_register(cfg.register, path)
 	return path
 end

--- a/lua/socks-copypath/init.lua
+++ b/lua/socks-copypath/init.lua
@@ -22,6 +22,13 @@ function M.setup(cfg)
 	end, {
 		desc = "Copy relative path of current file",
 	})
+
+	vim.api.nvim_create_user_command("CopyFileName", function()
+		local path = api.copy_file_name(config:get())
+		print("Copied " .. path)
+	end, {
+		desc = "Copy name of current file",
+	})
 end
 
 return M


### PR DESCRIPTION
Hi! Can I contribute a new function into your code? I like your plugin and I use it with my neovim setup but I need a function to copy a filename without path and extension to use with telescope live grep. I hope you can review it. Thanks.