### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - directory: /
-    open-pull-requests-limit: 5
-    package-ecosystem: github-actions
-    schedule:
-      day: friday
-      interval: weekly

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     ":automergeAll",
+    ":disableDependencyDashboard",
     ":prHourlyLimit4",
     ":label(dependencies)"
   ]


### PR DESCRIPTION
## What

- Disable dependabot.
    - To use Renovate instead of dependabot.
- Disable renovate dependency dashboard.
